### PR TITLE
Add explicit sync. point in the debugging with SYCL streams example

### DIFF
--- a/cpp-project/src/exercises/sycl_debugging.cpp
+++ b/cpp-project/src/exercises/sycl_debugging.cpp
@@ -2,16 +2,23 @@
 namespace sycl = cl::sycl;
 class printkernel;
 
-int main(int, char**) {
+int main(int, char **) {
   sycl::queue queue(sycl::default_selector{});
 
-  queue.submit([&] (sycl::handler& cgh) {
-     sycl::stream out(1024, 256, cgh);
+  queue.submit([&](sycl::handler &cgh) {
+    sycl::stream out(1024, 256, cgh);
 
-     cgh.single_task<class printkernel>([=] {
-       out << "Hello stream!" << sycl::endl;
-     } );
-   } );
+    cgh.single_task<class printkernel>(
+        [=] { out << "Hello stream!" << sycl::endl; });
+  });
 
-   return 0;
- }
+  /* Wait for the command queue to finish!
+   * This explicit synchronisation point is required because a SYCL
+   * command queue submits the command group inside it asynchronously. Thus,
+   * if there are no dependencies such as memory objects (buffers) or other
+   * kernels, the program control will be returned back to the host device
+   * before starting the execution of the kernel. */
+  queue.wait_and_throw();
+
+  return 0;
+}


### PR DESCRIPTION
## Fix for the debugging example

SYCL 1.2.1 relaxes the `queue submission` implementation in a way that for simple kernels with no dependencies, you have to manually block the return to host by adding a synchronization point for the queue to wait for the command group to finish execution on the device.